### PR TITLE
yte v1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "yte" %}
-{% set version = "1.2.3" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 80f7786968ebf2fa8af3631a1c88575a4da01de1e0e927d252fabebfd4f6666e
+  sha256: 2fd66a470a9e817229c841917050179e13314c0831b698520e4e4880f1bb8da4
 
 build:
   number: 0
@@ -26,10 +26,12 @@ requirements:
     - poetry
     - plac
     - pyyaml
+    - dpath
   run:
     - python
     - plac
     - pyyaml
+    - dpath
 
 test:
   imports:


### PR DESCRIPTION
This PR adds the missing `dpath` dependency to the recipe and update to `v1.3.0`.